### PR TITLE
Change references to phone to id

### DIFF
--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidAnimalAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidAnimalAddressBook.json
@@ -1,11 +1,11 @@
 {
   "animals": [ {
     "name": "Valid Animal",
-    "phone": "9482424",
+    "id": "9482424",
     "species": "4th street"
   }, {
-    "name": "Animal With Invalid Phone Field",
-    "phone": "948asdf2424",
+    "name": "Animal With Invalid Id Field",
+    "id": "948asdf2424",
     "species": "4th street"
   } ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAnimalAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAnimalAddressBook.json
@@ -1,7 +1,7 @@
 {
   "animals": [ {
     "name": "Animal with invalid name field: Ha!ns Mu@ster",
-    "phone": "9482424",
+    "id": "9482424",
     "species": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidAnimalAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidAnimalAddressBook.json
@@ -1,7 +1,7 @@
 {
   "animals": [ {
-    "name": "Hans Muster",
-    "phone": "9482424",
+    "nameDDDDD": "Hans Muster",
+    "id": "9482424",
     "species": "4th street"
   } ]
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -76,14 +76,14 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_ID_DESC, Id.MESSAGE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, "1" + INVALID_ID_DESC, Id.MESSAGE_CONSTRAINTS); // invalid id
         assertParseFailure(parser, "1" + INVALID_SPECIES_DESC, Species.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid id followed by valid species
         assertParseFailure(parser, "1" + INVALID_ID_DESC + SPECIES_DESC_AMY, Id.MESSAGE_CONSTRAINTS);
 
-        // valid phone followed by invalid phone. The test case for invalid phone followed by valid phone
+        // valid id followed by invalid id. The test case for invalid id followed by valid id
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + ID_DESC_BOB + INVALID_ID_DESC, Id.MESSAGE_CONSTRAINTS);
 

--- a/src/test/java/seedu/address/model/animal/IdTest.java
+++ b/src/test/java/seedu/address/model/animal/IdTest.java
@@ -14,27 +14,27 @@ public class IdTest {
     }
 
     @Test
-    public void constructor_invalidPhone_throwsIllegalArgumentException() {
-        String invalidPhone = "";
-        assertThrows(IllegalArgumentException.class, () -> new Id(invalidPhone));
+    public void constructor_invalidId_throwsIllegalArgumentException() {
+        String invalidId = "";
+        assertThrows(IllegalArgumentException.class, () -> new Id(invalidId));
     }
 
     @Test
-    public void isValidPhone() {
-        // null phone number
+    public void isValidId() {
+        // null id number
         assertThrows(NullPointerException.class, () -> Id.isValidId(null));
 
-        // invalid phone numbers
+        // invalid id numbers
         assertFalse(Id.isValidId("")); // empty string
         assertFalse(Id.isValidId(" ")); // spaces only
         assertFalse(Id.isValidId("91")); // less than 3 numbers
-        assertFalse(Id.isValidId("phone")); // non-numeric
+        assertFalse(Id.isValidId("id")); // non-numeric
         assertFalse(Id.isValidId("9011p041")); // alphabets within digits
         assertFalse(Id.isValidId("9312 1534")); // spaces within digits
 
-        // valid phone numbers
+        // valid id numbers
         assertTrue(Id.isValidId("911")); // exactly 3 numbers
         assertTrue(Id.isValidId("93121534"));
-        assertTrue(Id.isValidId("124293842033123")); // long phone numbers
+        assertTrue(Id.isValidId("124293842033123")); // long id numbers
     }
 }


### PR DESCRIPTION
References to Address are all part of AddressBook, hence cannot be replaced with Species. Need a separate issue to rename AddressBook references to something like ZooKeep. Resolves #70 