### PR TITLE
Change id variable name in AnimalCard to index for accuracy

### DIFF
--- a/src/main/java/seedu/address/ui/AnimalCard.java
+++ b/src/main/java/seedu/address/ui/AnimalCard.java
@@ -31,7 +31,7 @@ public class AnimalCard extends UiPart<Region> {
     @FXML
     private Label name;
     @FXML
-    private Label id;
+    private Label index;
     @FXML
     private Label identity;
     @FXML
@@ -45,7 +45,7 @@ public class AnimalCard extends UiPart<Region> {
     public AnimalCard(Animal animal, int displayedIndex) {
         super(FXML);
         this.animal = animal;
-        id.setText(displayedIndex + ". ");
+        index.setText(displayedIndex + ". ");
         name.setText(animal.getName().fullName);
         identity.setText(animal.getId().value);
         species.setText(animal.getSpecies().value);
@@ -68,7 +68,7 @@ public class AnimalCard extends UiPart<Region> {
 
         // state check
         AnimalCard card = (AnimalCard) other;
-        return id.getText().equals(card.id.getText())
+        return index.getText().equals(card.index.getText())
                 && animal.equals(card.animal);
     }
 }

--- a/src/main/resources/view/AnimalListCard.fxml
+++ b/src/main/resources/view/AnimalListCard.fxml
@@ -19,7 +19,7 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
+        <Label fx:id="index" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />


### PR DESCRIPTION
We had 2 fields named "id" and "identity". The "id" was used for indexing. Hence changed to "index" for accuracy.