### PR TITLE
Add undo command

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -12,8 +12,10 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.ZooKeepBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.HistoryStack;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyZooKeepBook;
+import seedu.address.model.ZooKeepBook;
 import seedu.address.model.animal.Animal;
 import seedu.address.storage.Storage;
 
@@ -27,6 +29,7 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final ZooKeepBookParser zooKeepBookParser;
+    private final HistoryStack historyStack;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -35,6 +38,8 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         zooKeepBookParser = new ZooKeepBookParser();
+        historyStack = HistoryStack.getHistoryStack();
+        historyStack.addToHistory(new ZooKeepBook(model.getZooKeepBook()));
     }
 
     @Override
@@ -45,8 +50,14 @@ public class LogicManager implements Logic {
         Command command = zooKeepBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
 
+        ReadOnlyZooKeepBook book = model.getZooKeepBook();
+        historyStack.addToHistory(new ZooKeepBook(book));
+
+        logger.info("--------------- ADDED CHANGE TO HISTORY STACK");
+        logger.info(historyStack.toString());
+
         try {
-            storage.saveZooKeepBook(model.getZooKeepBook());
+            storage.saveZooKeepBook(book);
         } catch (IOException ioe) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.HistoryStack;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyZooKeepBook;
+
+/**
+ * Undoes the most recently performed action.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_SUCCESS = "Undo successful";
+    public static final String MESSAGE_NO_UNDO = "Nothing left to undo";
+
+    private final HistoryStack historyStack;
+
+    /**
+     * Creates an UndoCommand that undos the last action
+     */
+    public UndoCommand() {
+        historyStack = HistoryStack.getHistoryStack();
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (historyStack.getSize() <= 1) {
+            throw new CommandException(MESSAGE_NO_UNDO);
+        }
+
+        historyStack.removeRecentHistory();
+        ReadOnlyZooKeepBook lastState = historyStack.viewRecentHistory();
+        model.setZooKeepBook(lastState);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UndoCommand // instanceof handles nulls
+                && historyStack.equals(((UndoCommand) other).historyStack));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -20,7 +20,7 @@ public class UndoCommand extends Command {
     private final HistoryStack historyStack;
 
     /**
-     * Creates an UndoCommand that undos the last action
+     * Creates an UndoCommand that undoes the last action
      */
     public UndoCommand() {
         historyStack = HistoryStack.getHistoryStack();

--- a/src/main/java/seedu/address/logic/parser/ZooKeepBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/ZooKeepBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class ZooKeepBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/HistoryStack.java
+++ b/src/main/java/seedu/address/model/HistoryStack.java
@@ -1,0 +1,53 @@
+package seedu.address.model;
+
+import java.util.Arrays;
+import java.util.Stack;
+
+/**
+ * Encapsulates a stack containing various states of the ZooKeepBook.
+ * This is a singleton.
+ */
+public class HistoryStack {
+
+    private static HistoryStack history;
+
+    private final Stack<ReadOnlyZooKeepBook> historyStack;
+
+    private HistoryStack() {
+        historyStack = new Stack<>();
+    }
+
+    public static HistoryStack getHistoryStack() {
+        if (history == null) {
+            history = new HistoryStack();
+        }
+        return history;
+    }
+
+    /**
+     * Push a read only state of ZooKeepBook into the stack
+     * @param book the ZooKeepBook to be pushed
+     */
+    public void addToHistory(ReadOnlyZooKeepBook book) {
+        if (getSize() == 0 || !viewRecentHistory().equals(book)) {
+            historyStack.push(book);
+        }
+    }
+
+    public void removeRecentHistory() {
+        historyStack.pop();
+    }
+
+    public ReadOnlyZooKeepBook viewRecentHistory() {
+        return historyStack.peek();
+    }
+
+    public int getSize() {
+        return historyStack.size();
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.toString(historyStack.toArray());
+    }
+}

--- a/src/main/java/seedu/address/model/HistoryStack.java
+++ b/src/main/java/seedu/address/model/HistoryStack.java
@@ -46,6 +46,10 @@ public class HistoryStack {
         return historyStack.size();
     }
 
+    public void clearHistory() {
+        historyStack.clear();
+    }
+
     @Override
     public String toString() {
         return Arrays.toString(historyStack.toArray());

--- a/src/main/java/seedu/address/model/ReadOnlyZooKeepBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyZooKeepBook.java
@@ -13,5 +13,4 @@ public interface ReadOnlyZooKeepBook {
      * This list will not contain any duplicate animals.
      */
     ObservableList<Animal> getAnimalList();
-
 }

--- a/src/main/java/seedu/address/model/ZooKeepBook.java
+++ b/src/main/java/seedu/address/model/ZooKeepBook.java
@@ -94,7 +94,6 @@ public class ZooKeepBook implements ReadOnlyZooKeepBook {
     }
 
     //// util methods
-
     @Override
     public String toString() {
         return animals.asUnmodifiableObservableList().size() + " animals";

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,156 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.HistoryStack;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.ReadOnlyZooKeepBook;
+import seedu.address.model.ZooKeepBook;
+import seedu.address.model.animal.Animal;
+import seedu.address.testutil.AnimalBuilder;
+
+public class UndoCommandTest {
+
+    @Test
+    public void execute_undoSuccessful() throws Exception {
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        ZooKeepBook bookA = new ZooKeepBook();
+        bookA.addAnimal(new AnimalBuilder().withName("Bob").build());
+
+        ZooKeepBook bookB = new ZooKeepBook();
+        bookB.addAnimal(new AnimalBuilder().withName("Bob").build());
+        bookB.addAnimal(new AnimalBuilder().withName("Tom").build());
+
+        historyStack.addToHistory(bookA);
+        historyStack.addToHistory(bookB);
+
+        ModelStub modelStub = new ModelStub();
+
+        CommandResult commandResult = new UndoCommand().execute(modelStub);
+
+        assertEquals(UndoCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(historyStack.getSize(), 1);
+    }
+
+    @Test
+    public void execute_noUndoAvailable_throwsCommandException() {
+        UndoCommand undoCommand = new UndoCommand();
+        ModelStub modelStub = new ModelStub();
+
+        assertThrows(CommandException.class, UndoCommand.MESSAGE_NO_UNDO, () -> undoCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        ZooKeepBook book = new ZooKeepBook();
+        book.addAnimal(new AnimalBuilder().withName("Bob").build());
+        historyStack.addToHistory(book);
+
+        UndoCommand undoCommand = new UndoCommand();
+
+        // same object -> returns true
+        assertTrue(undoCommand.equals(undoCommand));
+
+        // same values -> returns true
+        UndoCommand undoCommandCopy = new UndoCommand();
+        assertTrue(undoCommand.equals(undoCommandCopy));
+
+        // different types -> returns false
+        assertFalse(undoCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(undoCommand.equals(null));
+
+    }
+
+    private class ModelStub implements Model {
+
+        private ZooKeepBook zooKeepBook = new ZooKeepBook();
+
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getZooKeepBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setZooKeepBookFilePath(Path zooKeepBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addAnimal(Animal animal) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setZooKeepBook(ReadOnlyZooKeepBook zooKeepBook) {
+            this.zooKeepBook.resetData(zooKeepBook);
+        }
+
+        @Override
+        public ReadOnlyZooKeepBook getZooKeepBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasAnimal(Animal animal) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteAnimal(Animal target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAnimal(Animal target, Animal editedAnimal) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Animal> getFilteredAnimalList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredAnimalList(Predicate<Animal> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/model/HistoryStackTest.java
+++ b/src/test/java/seedu/address/model/HistoryStackTest.java
@@ -1,0 +1,70 @@
+package seedu.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class HistoryStackTest {
+
+    @Test
+    public void execute_get_historyStack() {
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        assertEquals(historyStack, HistoryStack.getHistoryStack());
+    }
+
+    @Test
+    public void execute_addToHistory_success() {
+        ZooKeepBook book = new ZooKeepBook();
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        historyStack.addToHistory(book);
+        assertEquals(historyStack.toString(), "[0 animals]");
+    }
+
+    @Test
+    public void execute_addToHistory_duplicate() {
+        ZooKeepBook bookA = new ZooKeepBook();
+        ZooKeepBook bookB = new ZooKeepBook();
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        historyStack.addToHistory(bookA);
+        historyStack.addToHistory(bookB);
+        assertEquals(historyStack.toString(), "[0 animals]");
+    }
+
+    @Test
+    public void execute_removeRecentHistory() {
+        ZooKeepBook book = new ZooKeepBook();
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        historyStack.addToHistory(book);
+        historyStack.removeRecentHistory();
+        assertEquals(historyStack.toString(), "[]");
+    }
+
+    @Test
+    public void execute_viewRecentHistory() {
+        ZooKeepBook book = new ZooKeepBook();
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        historyStack.addToHistory(book);
+        assertEquals(historyStack.viewRecentHistory().toString(), "0 animals");
+    }
+
+    @Test
+    public void execute_getSize() {
+        ZooKeepBook book = new ZooKeepBook();
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        historyStack.addToHistory(book);
+        assertEquals(historyStack.getSize(), 1);
+    }
+
+    @Test
+    public void execute_clearHistory() {
+        ZooKeepBook book = new ZooKeepBook();
+        HistoryStack historyStack = HistoryStack.getHistoryStack();
+        historyStack.clearHistory();
+        assertEquals(historyStack.toString(), "[]");
+    }
+}


### PR DESCRIPTION
Command word is "undo".
Undo command is implemented with a stack wrapped in a new class [HistoryStack].
HistoryStack is a singleton since only a single stack should exist in the running of the app.
HistoryStack supports the common methods of a usual stack, and stores ReadOnlyZooKeepBook.
Every change in state causes a copy of the ZooKeepBook to be made, and is pushed into the stack.
When an undo is called, the stack is popped and the model loads the top of the stack (Reverts to last state).
If a command does not incur a change in state (list, help) the state is not pushed onto the stack.
Resolves #103 