### PR TITLE
Modify find command to allow substring matching

### DIFF
--- a/src/main/java/seedu/zookeep/commons/util/StringUtil.java
+++ b/src/main/java/seedu/zookeep/commons/util/StringUtil.java
@@ -5,7 +5,6 @@ import static seedu.zookeep.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Arrays;
 
 /**
  * Helper functions for handling strings.
@@ -34,8 +33,23 @@ public class StringUtil {
         String preppedSentence = sentence;
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
-        return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+        for (String singleWord : wordsInPreppedSentence) {
+            if (containsIgnoreCase(singleWord, preppedWord)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if {@code str} contains the {@code subString}, both converted to lowercase.
+     * @param str cannot be null
+     * @param subString cannot be null, cannot be empty, must be a single word
+     * @return
+     */
+    public static boolean containsIgnoreCase(String str, String subString) {
+        return str.toLowerCase().contains(subString.toLowerCase());
     }
 
     /**

--- a/src/test/java/seedu/zookeep/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/zookeep/commons/util/StringUtilTest.java
@@ -109,7 +109,7 @@ public class StringUtilTest {
         assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
 
         // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
         assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
 
         // Matches word in the sentence, different upper/lower case letters

--- a/src/test/java/seedu/zookeep/model/animal/AnimalContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/zookeep/model/animal/AnimalContainsKeywordsPredicateTest.java
@@ -75,8 +75,13 @@ public class AnimalContainsKeywordsPredicateTest {
         predicate = new AnimalContainsKeywordsPredicate(Arrays.asList("Coco"));
         assertFalse(predicate.test(new AnimalBuilder().withName("Ahmeng Buttercup").build()));
 
-        // Multiple non-matching keywords
+        // Multiple keywords, with one keyword partially matching
         predicate = new AnimalContainsKeywordsPredicate(Arrays.asList("0000123", "Reti", "Anaconda"));
+        assertTrue(predicate.test(new AnimalBuilder().withName("Buttercup").withId("000123")
+                .withSpecies("Reticulated Python").build()));
+
+        // Multiple non-matching keywords
+        predicate = new AnimalContainsKeywordsPredicate(Arrays.asList("0000123", "Lopez", "Anaconda"));
         assertFalse(predicate.test(new AnimalBuilder().withName("Buttercup").withId("000123")
                 .withSpecies("Reticulated Python").build()));
     }


### PR DESCRIPTION
One issue was raised where 'find fish' could not detect a clownfish in the ZooKeep book. To make the application more flexible, you can now use the find command to find and list all animals whose fields contain any of the specified argument keywords, even if the keywords match only substrings in those fields.