### PR TITLE
Fix sorting of id

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -178,7 +178,7 @@ An animal can have any number of medical conditions and feed times (including 0)
 
 * If you enter an `ID` with leading zeroes, those zeroes will be trimmed during command execution.
 
-* `ID` should be at least 3 digits long (not counting leading zeroes, if any).
+* `ID` should be a number from 100 to 999999, inclusive.
 
 * `ID` of animal to add must not already exist in your `ZooKeep` book.
 
@@ -225,7 +225,7 @@ Format: `delete ID`
 
 * If you enter an `ID` with leading zeroes, those zeroes will be trimmed during command execution.
 
-* `ID` should be at least 3 digits long (not counting leading zeroes, if any).
+* `ID` should be a number from 100 to 999999, inclusive.
 
 * `ID` of animal to delete must exist in your `ZooKeep` book.
 </div>
@@ -335,7 +335,7 @@ An animal can have any number of medical conditions and feed times (including 0)
 
 * If you enter an `ID` with leading zeroes, those zeroes will be trimmed during command execution.
 
-* `ID` should be at least 3 digits long (not counting leading zeroes, if any).
+* `ID` should be a number from 100 to 999999, inclusive.
 
 * `ID` of animal must exist in your `ZooKeep` book.
 
@@ -391,7 +391,7 @@ An animal can have any number of medical conditions and feed times (including 0)
 
 * If you enter an `ID` with leading zeroes, those zeroes will be trimmed during command execution.
 
-* `ID` should be at least 3 digits long (not counting leading zeroes, if any).
+* `ID` should be a number from 100 to 999999, inclusive.
 
 * `ID` of animal must exist in your `ZooKeep` book.
 
@@ -474,7 +474,7 @@ Format: `sort CATEGORY`
 
 These are the category options you can sort the animals by:
 
-* `name`: Sorts all animals by their name in alphabetical order.
+* `name`: Sorts all animals by their name in alphabetical order (case-insensitive).
 * `id`: Sorts all animals by their id in ascending order.
 * `feedtime`: Sorts all animals by their earliest feed time in chronological order.
 * `medical`: Sorts all animals by their number of medical conditions in ascending order.
@@ -525,7 +525,7 @@ This command is useful for storing important archives in the `data/snapshots` fo
 to refer to the information of animals that have been deleted long ago. When executed, this command will
 create a snapshot of the current `ZooKeep` book data, saved as a file with the user specified file name.
 
-Please refer to the [FAQs](#faq) to find out how to load a snapshot that you have saved.
+Please refer to the [FAQ](#faq) to find out how to load a snapshot that you have saved.
 
 Format: `snap FILE_NAME`
 

--- a/src/main/java/seedu/zookeep/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/zookeep/logic/commands/DeleteCommand.java
@@ -20,7 +20,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the animal identified by the ID in the displayed animal list.\n"
-            + "Parameters: ID (must be a positive integer > 3 digits)\n"
+            + "Parameters: ID (must be a positive integer of at least 3 digits and at most 6 digits)\n"
             + "Example: " + COMMAND_WORD + " 123";
 
     public static final String MESSAGE_DELETE_ANIMAL_SUCCESS = "Deleted Animal\n%1$s";

--- a/src/main/java/seedu/zookeep/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/zookeep/logic/commands/DeleteCommand.java
@@ -20,7 +20,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the animal identified by the ID in the displayed animal list.\n"
-            + "Parameters: ID (must be a positive integer of at least 3 digits and at most 6 digits)\n"
+            + "Parameters: ID (must be a number from 100 to 999999, inclusive)\n"
             + "Example: " + COMMAND_WORD + " 123";
 
     public static final String MESSAGE_DELETE_ANIMAL_SUCCESS = "Deleted Animal\n%1$s";

--- a/src/main/java/seedu/zookeep/model/animal/Id.java
+++ b/src/main/java/seedu/zookeep/model/animal/Id.java
@@ -11,8 +11,8 @@ public class Id {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "ID numbers should only contain numbers with no leading zeroes, and it should be at least 3 digits "
-                    + "and at most 6 digits long";
+            "ID numbers should only contain numbers with no leading zeroes "
+                    + "and they must be a number from 100 to 999999, inclusive ";
     public static final String VALIDATION_REGEX = "\\d{3,6}";
     public final String value;
 

--- a/src/main/java/seedu/zookeep/model/animal/Id.java
+++ b/src/main/java/seedu/zookeep/model/animal/Id.java
@@ -12,7 +12,7 @@ public class Id {
 
     public static final String MESSAGE_CONSTRAINTS =
             "ID numbers should only contain numbers with no leading zeroes, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String VALIDATION_REGEX = "\\d{3,6}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/zookeep/model/animal/Id.java
+++ b/src/main/java/seedu/zookeep/model/animal/Id.java
@@ -11,7 +11,8 @@ public class Id {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "ID numbers should only contain numbers with no leading zeroes, and it should be at least 3 digits long";
+            "ID numbers should only contain numbers with no leading zeroes, and it should be at least 3 digits "
+                    + "and at most 6 digits long";
     public static final String VALIDATION_REGEX = "\\d{3,6}";
     public final String value;
 

--- a/src/test/java/seedu/zookeep/logic/commands/AppendCommandTest.java
+++ b/src/test/java/seedu/zookeep/logic/commands/AppendCommandTest.java
@@ -92,10 +92,10 @@ public class AppendCommandTest {
 
     @Test
     public void execute_invalidAnimalId_failure() {
-        Id outOfBoundId = new Id("99999999999999");
-        assert model.getAnimal(outOfBoundId).equals(Optional.empty());
+        Id invalidId = new Id("999999"); // max possible Id as well
+        assert model.getAnimal(invalidId).equals(Optional.empty());
         EditAnimalDescriptor descriptor = new EditAnimalDescriptorBuilder().withFeedTimes(FEED_TIMES).build();
-        AppendCommand appendCommand = new AppendCommand(outOfBoundId, descriptor);
+        AppendCommand appendCommand = new AppendCommand(invalidId, descriptor);
 
         assertCommandFailure(appendCommand, model, Messages.MESSAGE_INVALID_ANIMAL_DISPLAYED_ID);
     }

--- a/src/test/java/seedu/zookeep/logic/commands/ReplaceCommandTest.java
+++ b/src/test/java/seedu/zookeep/logic/commands/ReplaceCommandTest.java
@@ -107,10 +107,10 @@ public class ReplaceCommandTest {
 
     @Test
     public void execute_invalidAnimalId_failure() {
-        Id outOfBoundId = new Id("99999999999999");
-        assert model.getAnimal(outOfBoundId).equals(Optional.empty());
+        Id invalidId = new Id("999999"); // max possible Id as well
+        assert model.getAnimal(invalidId).equals(Optional.empty());
         EditAnimalDescriptor descriptor = new EditAnimalDescriptorBuilder().withName(VALID_NAME_BAILEY).build();
-        ReplaceCommand replaceCommand = new ReplaceCommand(outOfBoundId, descriptor);
+        ReplaceCommand replaceCommand = new ReplaceCommand(invalidId, descriptor);
 
         assertCommandFailure(replaceCommand, model, Messages.MESSAGE_INVALID_ANIMAL_DISPLAYED_ID);
     }

--- a/src/test/java/seedu/zookeep/model/animal/IdTest.java
+++ b/src/test/java/seedu/zookeep/model/animal/IdTest.java
@@ -28,13 +28,13 @@ public class IdTest {
         assertFalse(Id.isValidId("")); // empty string
         assertFalse(Id.isValidId(" ")); // spaces only
         assertFalse(Id.isValidId("91")); // less than 3 numbers
+        assertFalse(Id.isValidId("93121534")); // more than 6 numbers
         assertFalse(Id.isValidId("id")); // non-numeric
         assertFalse(Id.isValidId("9011p041")); // alphabets within digits
         assertFalse(Id.isValidId("9312 1534")); // spaces within digits
 
         // valid id numbers
         assertTrue(Id.isValidId("911")); // exactly 3 numbers
-        assertTrue(Id.isValidId("93121534"));
-        assertTrue(Id.isValidId("124293842033123")); // long id numbers
+        assertTrue(Id.isValidId("654321")); // long id numbers (6 numbers)
     }
 }

--- a/src/test/java/seedu/zookeep/model/animal/IdTest.java
+++ b/src/test/java/seedu/zookeep/model/animal/IdTest.java
@@ -27,14 +27,19 @@ public class IdTest {
         // invalid id numbers
         assertFalse(Id.isValidId("")); // empty string
         assertFalse(Id.isValidId(" ")); // spaces only
+        assertFalse(Id.isValidId("-123")); // negative numbers
         assertFalse(Id.isValidId("91")); // less than 3 numbers
+        assertFalse(Id.isValidId("99")); // just below lower boundary
+        assertFalse(Id.isValidId("1000000")); // just above upper boundary
         assertFalse(Id.isValidId("93121534")); // more than 6 numbers
         assertFalse(Id.isValidId("id")); // non-numeric
         assertFalse(Id.isValidId("9011p041")); // alphabets within digits
         assertFalse(Id.isValidId("9312 1534")); // spaces within digits
 
         // valid id numbers
+        assertTrue(Id.isValidId("100")); // lower boundary exactly
         assertTrue(Id.isValidId("911")); // exactly 3 numbers
         assertTrue(Id.isValidId("654321")); // long id numbers (6 numbers)
+        assertTrue(Id.isValidId("999999")); // upper boundary exactly
     }
 }


### PR DESCRIPTION
Set limit of id to be at most 6 digits long. 
Made changes to the Id references and helped to fix the FAQ hyperlink in the UG.
Resolves #236.